### PR TITLE
Clarify goal of the spec + trailing commas seperate page

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -9,6 +9,8 @@ layout: default
 
 JSONC (JSON with Comments) is an extension of JSON (JavaScript Object Notation) that allows comments within JSON data. This specification defines the syntax and semantics of JSONC.
 
+The JSONC format was informally introduced by Microsoft to be used for VS Code's configuration files (settings.json, launch.json, tasks.json, etc.). Alongside the informal format, a publicly available parser ([jsonc-parser](https://www.npmjs.com/package/jsonc-parser)) was supplied to parse those configuration files. The goal of this specification is to formalize the JSONC format as what the jsonc-parser considers valid while using its default configurations.
+
 ## Syntax
 
 JSONC follows the same syntax rules as JSON with the addition of JavaScript style comments. Comments can be either single-line or multi-line.
@@ -42,7 +44,7 @@ Multi-line comments start with `/*` and end with `*/`. They can span multiple li
 
 ## Trailing commas
 
-JSONC doesn't allow trailing commas; however, we encourage parsers to be lenient and handle trailing commas gracefully where possible to reduce the risk of human edits introducing parsing errors.[^1]
+JSONC doesn't allow trailing commas. Indeed, the jsonc-parser doesn't support them while using default configurations since `allowTrailingComma` is an optional parameter that is false by default. For more information regarding trailing commas, please refer to the [trailing commas information page](/trailingcommas).
 
 ## Semantics
 
@@ -90,9 +92,5 @@ Here is a non-exhaustive list:
 
 **Rust**
 - [dprint/jsonc-parser](https://github.com/dprint/jsonc-parser)
-
----
-
-[^1]: In VS Code, "the [JSONC] mode also accepts trailing commas, but they are discouraged and the editor will display a warning." ([source](https://code.visualstudio.com/docs/languages/json#_json-with-comments))
 
 

--- a/index.markdown
+++ b/index.markdown
@@ -9,7 +9,9 @@ layout: default
 
 JSONC (JSON with Comments) is an extension of JSON (JavaScript Object Notation) that allows comments within JSON data. This specification defines the syntax and semantics of JSONC.
 
-The JSONC format was informally introduced by Microsoft to be used for VS Code's configuration files (settings.json, launch.json, tasks.json, etc.). Alongside the informal format, a publicly available parser ([jsonc-parser](https://www.npmjs.com/package/jsonc-parser)) was supplied to parse those configuration files. The goal of this specification is to formalize the JSONC format as what the jsonc-parser considers valid while using its default configurations.
+The JSONC format was informally introduced by Microsoft to be used for VS Code's configuration files (`settings.json`, `launch.json`, `tasks.json`, etc). Alongside the informal format, a publicly-available parser ([`jsonc-parser`]) was supplied to parse those configuration files. The goal of this specification is to formalize the JSONC format as what [`jsonc-parser`] considers valid while using its default configurations.
+
+[`jsonc-parser`]: https://www.npmjs.com/package/jsonc-parser
 
 ## Syntax
 

--- a/index.markdown
+++ b/index.markdown
@@ -46,7 +46,7 @@ Multi-line comments start with `/*` and end with `*/`. They can span multiple li
 
 ## Trailing commas
 
-JSONC doesn't allow trailing commas. Indeed, the jsonc-parser doesn't support them while using default configurations since `allowTrailingComma` is an optional parameter that is false by default. For more information regarding trailing commas, please refer to the [trailing commas information page](/trailingcommas).
+JSONC doesn't allow trailing commas. For more information regarding trailing commas, refer to the [trailing commas information page](/trailingcommas).
 
 ## Semantics
 

--- a/trailingcommas.markdown
+++ b/trailingcommas.markdown
@@ -1,0 +1,29 @@
+---
+
+layout: default
+---
+
+# Trailing Commas and JSONC
+
+## Why Trailing Commas Aren't Part of the JSONC Specification?
+
+Trailing commas are not part of the JSONC Specification because the reference implementation, [jsonc-parser](https://www.npmjs.com/package/jsonc-parser), does not allow them unless explicitly configured. The `allowTrailingComma` option is set to `false` by default, so any trailing comma will result in a parsing error. 
+
+The reason why this specification chose the default behavior of the parser as the reference for the standard is to ensure that JSONC remains compatible with the broader JSON ecosystem, which does not allow trailing commas. This decision helps maintain consistency and predictability across different parsers and implementations. Namely, the tsconfig and eslint config files, which are widely used in the JavaScript ecosystem, do not allow trailing commas in their JSONC files.
+
+The exclusion of trailing commas also facilitates the creation of tools and libraries that can parse JSONC without needing to handle additional syntax variations. This helps ensure that JSONC remains a lightweight and straightforward extension of JSON, primarily focused on adding comments without introducing significant complexity.
+
+## Can a Parser Choose to Support Trailing Commas?
+
+Yes, a parser can choose to support trailing commas in JSONC files for convenience. This is especially useful in configuration files or code where lists and objects are frequently edited. Allowing trailing commas can make adding, removing, or reordering items easier and reduce the likelihood of syntax errors. 
+
+However, this is not part of the official JSONC specification and such support would be considered an extension or variation of the standard JSONC format. This means that while a parser may allow trailing commas, it may not be compatible with all JSONC parsers or tools that strictly adhere to the JSONC specification without trailing commas.
+
+## Trailing Commas in VS Code
+
+The "JSON with Comments" mode in VS Code used to allow trailing commas without any warnings by default, but this was eventually changed to discourage their use and promote better compatibility with other JSONC parsers ([source](https://github.com/microsoft/vscode/issues/102061)).
+
+At the time of writing this document, the "JSON with Comments" mode still accepts trailing commas, but it discourages their usage by displaying a warning ([source](https://code.visualstudio.com/docs/languages/json#_json-with-comments)) unless the file is one of the VS Code official configuration files. The exclusion of those configuration files comes from the JSON schema used. The schema for these files explicitly allow trailing commas, which is why they are accepted without warnings in that specific context.
+
+
+

--- a/trailingcommas.markdown
+++ b/trailingcommas.markdown
@@ -13,11 +13,9 @@ The reason why this specification chose the default behavior of the parser as th
 
 The exclusion of trailing commas also facilitates the creation of tools and libraries that can parse JSONC without needing to handle additional syntax variations. This helps ensure that JSONC remains a lightweight and straightforward extension of JSON, primarily focused on adding comments without introducing significant complexity.
 
-## Can a Parser Choose to Support Trailing Commas?
+## Can a Parser That Chooses to Support Trailing Commas Still Be Considered a JSONC Parser?
 
-Yes, a parser can choose to support trailing commas in JSONC files for convenience. This is especially useful in configuration files or code where lists and objects are frequently edited. Allowing trailing commas can make adding, removing, or reordering items easier and reduce the likelihood of syntax errors. 
-
-However, this is not part of the official JSONC specification and such support would be considered an extension or variation of the standard JSONC format. This means that while a parser may allow trailing commas, it may not be compatible with all JSONC parsers or tools that strictly adhere to the JSONC specification without trailing commas.
+Yes, however this is not part of the official JSONC specification and such support would be considered an extension or variation of the standard JSONC format. This means that while a parser may allow trailing commas, it may not be compatible with all JSONC parsers or tools that strictly adhere to the JSONC specification without trailing commas.
 
 ## Trailing Commas in VS Code
 

--- a/trailingcommas.markdown
+++ b/trailingcommas.markdown
@@ -9,7 +9,7 @@ layout: default
 
 Trailing commas are not part of the JSONC Specification because the reference implementation, [jsonc-parser](https://www.npmjs.com/package/jsonc-parser), does not allow them unless explicitly configured. The `allowTrailingComma` option is set to `false` by default, so any trailing comma will result in a parsing error. 
 
-The reason why this specification chose the default behavior of the parser as the reference for the standard is to ensure that JSONC remains compatible with the broader JSON ecosystem, which does not allow trailing commas. This decision helps maintain consistency and predictability across different parsers and implementations. Namely, the tsconfig and eslint config files, which are widely used in the JavaScript ecosystem, do not allow trailing commas in their JSONC files.
+The reason why this specification chose the default behavior of the parser as the reference for the standard is to ensure that JSONC remains compatible with the broader JSON ecosystem, which does not allow trailing commas. This decision helps maintain consistency and predictability across different parsers and implementations. Namely, the [TSConfig](https://www.typescriptlang.org/tsconfig/) and [ESLint config](https://eslint.org/docs/latest/use/configure/configuration-files) files, which are widely used in the JavaScript ecosystem, do not allow trailing commas in their JSONC files.
 
 The exclusion of trailing commas also facilitates the creation of tools and libraries that can parse JSONC without needing to handle additional syntax variations. This helps ensure that JSONC remains a lightweight and straightforward extension of JSON, primarily focused on adding comments without introducing significant complexity.
 

--- a/trailingcommas.markdown
+++ b/trailingcommas.markdown
@@ -15,7 +15,7 @@ The exclusion of trailing commas also facilitates the creation of tools and libr
 
 ## Can a Parser That Chooses to Support Trailing Commas Still Be Considered a JSONC Parser?
 
-Yes, however this is not part of the official JSONC specification and such support would be considered an extension or variation of the standard JSONC format. This means that while a parser may allow trailing commas, it may not be compatible with all JSONC parsers or tools that strictly adhere to the JSONC specification without trailing commas.
+Yes, however this is not part of the JSONC.org specification and such support would be considered an extension or variation of the standard JSONC format. This means that while a parser may allow trailing commas, it may not be compatible with all JSONC parsers or tools that strictly adhere to the JSONC specification without trailing commas.
 
 ## Trailing Commas in VS Code
 


### PR DESCRIPTION
The additions here aim to clarify the goal of the spec:
Provide a definition in accordance with jsonc-parser.

To avoid any ambiguity regarding whether or not a parser needs to implement trailing commas, a separate page is introduced to add more details about them, while keeping the spec short and clear. This should address https://github.com/DecimalTurn/JSONC/issues/5.