### PR TITLE
Fix typo Elexir -> Elixir

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -79,7 +79,7 @@ Here is a non-exhaustive list:
 **C++**
 - [stephenberry/glaze](https://github.com/stephenberry/glaze)
 
-**Elexir**
+**Elixir**
 - [massivefermion/jsonc](https://github.com/massivefermion/jsonc)
 
 **Go**


### PR DESCRIPTION
I hope directly making a PR is appropriate here, since it's pretty simple typo fix.